### PR TITLE
修复当使用 Dialog 展示时，主窗体不为当前活动窗体时无法关闭的问题

### DIFF
--- a/src/Shared/HandyControl_Shared/Controls/Dialog/Dialog.cs
+++ b/src/Shared/HandyControl_Shared/Controls/Dialog/Dialog.cs
@@ -110,7 +110,7 @@ namespace HandyControl.Controls
             AdornerDecorator decorator;
             if (string.IsNullOrEmpty(token))
             {
-                element = WindowHelper.GetActiveWindow();
+                element = WindowHelper.GetActiveWindow() ?? Application.Current.MainWindow;
                 decorator = VisualHelper.GetChild<AdornerDecorator>(element);
             }
             else
@@ -147,7 +147,7 @@ namespace HandyControl.Controls
         {
             if (string.IsNullOrEmpty(_token))
             {
-                Close(WindowHelper.GetActiveWindow());
+                Close(WindowHelper.GetActiveWindow() ?? Application.Current.MainWindow);
             }
             else if (ContainerDic.TryGetValue(_token, out var element))
             {


### PR DESCRIPTION
在使用 Dialog 做异步任务处理的时候，如果用户切换应用导致主应用处于非活动状态时，对应的 Dialog 无法关闭